### PR TITLE
loadCookie encoding issue

### DIFF
--- a/common.py
+++ b/common.py
@@ -153,7 +153,7 @@ async def drawPix(x, y, data, cookies, cookieName):
 
 def loadCookie(path):
     d = {}
-    with open(path, "rb") as f:
+    with open(path, encoding='utf-8') as f:
         l = json.load(f)
         for x in l:
             d[x["name"]] = x["value"]


### PR DESCRIPTION
Not sure if you care but I found this small issue while trying to run your code.
Running your code on my computer gives me a  "JSON object must be str, not 'bytes'" error, and I changed it according to some Google search on this. Then the code runs perfectly.

(I'm completely new to python and I don't know if this problem is relevant. I apologize if this is not helpful at all.)

